### PR TITLE
feature: enable migrate msg to be either a struct or an enum

### DIFF
--- a/pkg/codegen/instantiate.go
+++ b/pkg/codegen/instantiate.go
@@ -24,7 +24,8 @@ func GenerateMigrateMsg(f *jen.File, schema *schemas.JSONSchema) {
 		return
 	}
 
-	generateStructMsg(f, schema, "MigrateMsg")
+	// MigrateMsg can be either a struct or an enum
+	generateStructOrEnumMsg(f, schema, "MigrateMsg")
 }
 
 func generateStructMsg(f *jen.File, schema *schemas.JSONSchema, allowedTitle string) {
@@ -46,11 +47,31 @@ func generateStructMsg(f *jen.File, schema *schemas.JSONSchema, allowedTitle str
 
 func validateAsStructMsg(schema *schemas.JSONSchema, allowedTitle string) error {
 	if schema.Title != allowedTitle {
-		return fmt.Errorf("title must be InstantiateMsg")
+		return fmt.Errorf("title must be %v", allowedTitle)
 	}
+
+	if schema.Type == nil {
+		return fmt.Errorf("%v type must be defined", allowedTitle)
+	}
+
 	if schema.Type[0] != "object" {
-		return fmt.Errorf("InstantiateMsg type must be object")
+		return fmt.Errorf("%v type must be object", allowedTitle)
 	}
 
 	return nil
+}
+
+// Generate the msg regardless if it is a struct or enum this is mostly needed for migration msgs
+func generateStructOrEnumMsg(f *jen.File, schema *schemas.JSONSchema, allowedTitle string) {
+	if schema == nil {
+		panic(fmt.Errorf("schema of %s is nil", allowedTitle))
+	}
+
+	err := validateAsStructMsg(schema, allowedTitle)
+	if err == nil {
+		generateStructMsg(f, schema, allowedTitle)
+	} else {
+		generateEnumMsg(f, schema, []string{allowedTitle, allowedTitle + "_for_Empty"})
+	}
+
 }

--- a/pkg/codegen/instantiate.go
+++ b/pkg/codegen/instantiate.go
@@ -73,5 +73,4 @@ func generateStructOrEnumMsg(f *jen.File, schema *schemas.JSONSchema, allowedTit
 	} else {
 		generateEnumMsg(f, schema, []string{allowedTitle, allowedTitle + "_for_Empty"})
 	}
-
 }


### PR DESCRIPTION
Working through a go-codegen failures while trying to generate types for DAODAO's `dao_core` contract, the root cause seemed to be that go-codegen insists that `MigrateMsg` is a struct, however for many more mature contracts that is not the case and migration requires an enum so I did the small amount of work to make that allowable and was able to successfully codegen said contract.