### PR TITLE
fix(interchaintest): use of incorrect contract package name in 'contract_test.go'

### DIFF
--- a/pkg/interchaintest/codegen.go
+++ b/pkg/interchaintest/codegen.go
@@ -130,7 +130,7 @@ func AddContract(schemaPath, suiteDir, contractName string) error {
 		}
 
 		relPackageDir := filepath.Join(relContractsDir, packageName)
-		contractTestGenerators, err := getContractTestGenerators(relPackageDir, goMod.Module.Mod.Path)
+		contractTestGenerators, err := getContractTestGenerators(relPackageDir, goMod.Module.Mod.Path, packageName)
 		if err != nil {
 			return err
 		}

--- a/pkg/interchaintest/generators.go
+++ b/pkg/interchaintest/generators.go
@@ -99,13 +99,14 @@ func getContractGenerators(idlSchema *schemas.IDLSchema, packageName, modulePath
 	return generators, nil
 }
 
-func getContractTestGenerators(relPackageDir, modulePath string) ([]*genny.Generator, error) {
+func getContractTestGenerators(relPackageDir, modulePath, packageName string) ([]*genny.Generator, error) {
 	var generators []*genny.Generator
 
 	// contract test generator
 	ctg, err := interchaintestv8.NewGeneratorForContractTest(&interchaintestv8.ContractTestOptions{
 		ModulePath:    modulePath,
 		RelPackageDir: relPackageDir,
+		PackageName:   packageName,
 	})
 	if err != nil {
 		return nil, err

--- a/templates/interchaintestv8/files/contract_test.go.plush
+++ b/templates/interchaintestv8/files/contract_test.go.plush
@@ -38,7 +38,7 @@ func (s *ContractTestSuite) TestContract() {
 
 	// Add your test code here. For example, upload and instantiate a contract:
 	// This boilerplate may be moved to SetupSuite if it is common to all tests.
-	var contract *cwicacontroller.Contract
+	var contract *<%= PackageName %>.Contract
 	s.Run("UploadAndInstantiateContract", func() {
 		// Upload the contract code to the chain.
 		codeID, err := wasmd1.StoreContract(ctx, s.UserA.KeyName(), "./relative/path/to/your_contract.wasm")
@@ -46,7 +46,7 @@ func (s *ContractTestSuite) TestContract() {
 
 		// Instantiate the contract using contract helpers.
 		// This will an error if the instantiate message is invalid.
-		contract, err = cwicacontroller.Instantiate(ctx, s.UserA.KeyName(), codeID, "", wasmd1, cwicacontroller.InstantiateMsg{})
+		contract, err = <%= PackageName %>.Instantiate(ctx, s.UserA.KeyName(), codeID, "", wasmd1, <%= PackageName %>.InstantiateMsg{})
 		s.Require().NoError(err)
 
 		s.Require().NotEmpty(contract.Address)

--- a/templates/interchaintestv8/options.go
+++ b/templates/interchaintestv8/options.go
@@ -17,6 +17,7 @@ type Options struct {
 type ContractTestOptions struct {
 	ModulePath    string
 	RelPackageDir string
+	PackageName   string
 }
 
 // Validate that Options is usable.
@@ -60,5 +61,6 @@ func (opts *ContractTestOptions) plushContext() *plush.Context {
 	ctx := plush.NewContext()
 	ctx.Set("ModulePath", opts.ModulePath)
 	ctx.Set("RelPackageDir", opts.RelPackageDir)
+	ctx.Set("PackageName", opts.PackageName)
 	return ctx
 }


### PR DESCRIPTION
closes: #82 