### PR TITLE
feat: manage map types with `additionalProperties`

### DIFF
--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -107,7 +107,7 @@ func (s *MySuite) TestQueryClient() {
 	s.GenerateQueryClientTest("testdata/ics721.json")
 	s.GenerateQueryClientTest("testdata/dao-dao-core.json")
 	s.GenerateQueryClientTest("testdata/axone-objectarium.json")
-	s.GenerateMessageTypesTest("testdata/map-test.json")
+	s.GenerateQueryClientTest("testdata/map-test.json")
 }
 
 func (s *MySuite) TestInterchaintestScaffold() {

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -93,6 +93,7 @@ func (s *MySuite) TestMessageComposer() {
 	s.GenerateMessageTypesTest("testdata/ics721.json")
 	s.GenerateMessageTypesTest("testdata/dao-dao-core.json")
 	s.GenerateMessageTypesTest("testdata/axone-objectarium.json")
+	s.GenerateMessageTypesTest("testdata/map-test.json")
 }
 
 func (s *MySuite) TestQueryClient() {
@@ -106,6 +107,7 @@ func (s *MySuite) TestQueryClient() {
 	s.GenerateQueryClientTest("testdata/ics721.json")
 	s.GenerateQueryClientTest("testdata/dao-dao-core.json")
 	s.GenerateQueryClientTest("testdata/axone-objectarium.json")
+	s.GenerateMessageTypesTest("testdata/map-test.json")
 }
 
 func (s *MySuite) TestInterchaintestScaffold() {

--- a/integration_test/testdata/map-test.json
+++ b/integration_test/testdata/map-test.json
@@ -1,0 +1,139 @@
+{
+  "contract_name": "map-test",
+  "contract_version": "0.0.1",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "description": "Instantiate message",
+    "type": "object",
+    "additionalProperties": false
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "description": "Execute messages",
+    "oneOf": [
+      {
+        "title": "Foo",
+        "type": "object",
+        "required": [
+          "foo"
+        ],
+        "properties": {
+          "foo": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "Query messages",
+    "oneOf": [
+      {
+        "title": "MapString",
+        "type": "object",
+        "required": [
+          "map_string"
+        ],
+        "properties": {
+          "map_string": {
+            "type": "object",
+            "required": [
+              "foo"
+            ],
+            "properties": {
+              "foo": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "map_with_value"
+        ],
+        "properties": {
+          "map_with_value": {
+            "type": "object",
+            "required": [
+              "foo"
+            ],
+            "properties": {
+              "foo": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/Value"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Value": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "map_string": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "BarResponse",
+      "type": "object",
+      "required": [
+        "foo"
+      ],
+      "properties": {
+        "foo": {
+          "description": "The foo value",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "map_with_value": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "BarResponse",
+      "type": "object",
+      "required": [
+        "foo"
+      ],
+      "properties": {
+        "foo": {
+          "description": "The foo value",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "description": "# map-test",
+  "title": "map-test"
+}

--- a/pkg/codegen/codegentests/cwics721_test.go
+++ b/pkg/codegen/codegentests/cwics721_test.go
@@ -267,8 +267,10 @@ type QueryMsg_OutgoingChannels struct {
 }
 type ExecuteMsg_ReceiveNft Cw721ReceiveMsg
 
-type ExecuteMsg_Pause struct{}
-type ExecuteMsg_Callback CallbackMsg
+type (
+	ExecuteMsg_Pause    struct{}
+	ExecuteMsg_Callback CallbackMsg
+)
 
 type ExecuteMsg_AdminCleanAndBurnNft struct {
 	ClassId    string `json:"class_id"`

--- a/pkg/codegen/properties.go
+++ b/pkg/codegen/properties.go
@@ -205,6 +205,12 @@ func getType(name string, schema *schemas.JSONSchema, required *bool, typePrefix
 
 			typeStr = "map[string]" + itemType
 			isOptional = false
+		case schema.AdditionalProperties.Bool != nil && *schema.AdditionalProperties.Bool:
+			if len(schema.Properties) > 0 {
+				return "", fmt.Errorf("cannot determine the type of object %s: properties and additionalProperties are both defined", name)
+			}
+			typeStr = "map[string]any"
+			isOptional = false
 		default:
 			return "", fmt.Errorf("cannot determine the type of object %s", name)
 		}

--- a/pkg/codegen/properties.go
+++ b/pkg/codegen/properties.go
@@ -198,6 +198,10 @@ func getType(name string, schema *schemas.JSONSchema, required *bool, typePrefix
 			if len(schema.Properties) > 0 {
 				return "", fmt.Errorf("cannot determine the type of object %s: properties and additionalProperties are both defined", name)
 			}
+			if schema.AdditionalProperties.JSONSchema.Properties != nil {
+				return "", fmt.Errorf("cannot determine the type of object %s: a sub-object is defined in 'additionalProperties', which is currently not supported, please report this issue in https://github.com/srdtrk/go-codegen", name)
+			}
+
 			itemType, err := getType(name, schema.AdditionalProperties.JSONSchema, nil, "", false)
 			if err != nil {
 				return "", err

--- a/pkg/codegen/properties.go
+++ b/pkg/codegen/properties.go
@@ -195,6 +195,9 @@ func getType(name string, schema *schemas.JSONSchema, required *bool, typePrefix
 				typeStr = strcase.ToCamel(k)
 			}
 		case schema.AdditionalProperties.JSONSchema != nil:
+			if len(schema.Properties) > 0 {
+				return "", fmt.Errorf("cannot determine the type of object %s: properties and additionalProperties are both defined", name)
+			}
 			itemType, err := getType(name, schema.AdditionalProperties.JSONSchema, nil, "", false)
 			if err != nil {
 				return "", err

--- a/pkg/codegen/properties.go
+++ b/pkg/codegen/properties.go
@@ -194,6 +194,14 @@ func getType(name string, schema *schemas.JSONSchema, required *bool, typePrefix
 			for k := range schema.Properties {
 				typeStr = strcase.ToCamel(k)
 			}
+		case schema.AdditionalProperties.JSONSchema != nil:
+			itemType, err := getType(name, schema.AdditionalProperties.JSONSchema, nil, "", false)
+			if err != nil {
+				return "", err
+			}
+
+			typeStr = "map[string]" + itemType
+			isOptional = false
 		default:
 			return "", fmt.Errorf("cannot determine the type of object %s", name)
 		}

--- a/pkg/schemas/schema.go
+++ b/pkg/schemas/schema.go
@@ -15,7 +15,7 @@ type JSONSchema struct {
 	Required             []string               `json:"required,omitempty"`             // Section 5.15.
 	Properties           map[string]*JSONSchema `json:"properties,omitempty"`           // Section 5.16.
 	PatternProperties    map[string]*JSONSchema `json:"patternProperties,omitempty"`    // Section 5.17.
-	AdditionalProperties *bool                  `json:"additionalProperties,omitempty"` // Section 5.18.
+	AdditionalProperties *JSONSchemaOrBool      `json:"additionalProperties,omitempty"` // Section 5.18.
 	Type                 TypeList               `json:"type,omitempty"`                 // Section 5.21.
 	AllOf                []*JSONSchema          `json:"allOf,omitempty"`                // Section 5.22.
 	AnyOf                []*JSONSchema          `json:"anyOf,omitempty"`                // Section 5.23.
@@ -82,4 +82,19 @@ func (t *TypeList) UnmarshalJSON(b []byte) error {
 	}
 
 	return nil
+}
+
+// JSONSchemaOrBool represents a JSONSchema or a boolean value.
+type JSONSchemaOrBool struct {
+	JSONSchema *JSONSchema
+	Bool       *bool
+}
+
+func (t *JSONSchemaOrBool) UnmarshalJSON(b []byte) error {
+	if err := json.Unmarshal(b, &t.Bool); err == nil {
+		return nil
+	}
+	t.Bool = nil
+	return json.Unmarshal(b, &t.JSONSchema)
+
 }

--- a/pkg/schemas/schema.go
+++ b/pkg/schemas/schema.go
@@ -96,5 +96,4 @@ func (t *JSONSchemaOrBool) UnmarshalJSON(b []byte) error {
 	}
 	t.Bool = nil
 	return json.Unmarshal(b, &t.JSONSchema)
-
 }


### PR DESCRIPTION
This Pull Request introduces improvements to the JSON schema generation process, specifically for `Map` types. These improvements are in line with the JSON schema draft documentation and the output from the [schemars](https://graham.cool/schemars/) tool.

When a `Map` is defined, it generates a JSON schema definition where `additionalProperties` is set to accept the type required by the map value type. 

Consider the following Rust code:

```rust
#[cw_serde]
#[derive(QueryResponses)]
pub enum QueryMsg {
    /// # MapString
    #[returns(BarResponse)]
    MapString { foo: BTreeMap<String, String> },
    #[returns(BarResponse)]
    MapWithValue { foo: BTreeMap<String, Value> },
}
```

This code generates the following JSON schemas:

```json
"map_string": {
    "type": "object",
    "required": ["foo"],
    "properties": {
        "foo": {
            "type": "object",
            "additionalProperties": {
                "type": "string"
            }
        }
    },
    "additionalProperties": false
}
```

```json
"map_with_value": {
    "type": "object",
    "required": ["foo"],
    "properties": {
        "foo": {
            "type": "object",
            "additionalProperties": {
                "$ref": "#/definitions/Value"
            }
        }
    },
    "additionalProperties": false
}
```

In Go, this should generate a `foo` property of type `map[string]string` for the first schema and `map[string]Value` for the second one. 

```go
type QueryMsg_MapString struct {
	Foo map[string]string `json:"foo"`
}
```

```go
type QueryMsg_MapWithValue struct {
	Foo map[string]Value `json:"foo"`
}
```

This PR includes modifications to the handling of the `additionalProperties` field, allowing it to accept either a boolean or a `JSONSchema`, in line with the [JSON schema specification](https://json-schema.org/understanding-json-schema/reference/object#additionalproperties). 

Furthermore, when `additionalProperties` is set to `true` (which is the default value in JSON Schema), it implies that the object can accept any property with any value. While this does not adhere strictly to the JSON schema specification (because we can set both `properties` and `addionalProperties`), it provides a more flexible approach to handling `additionalProperties`.
